### PR TITLE
Minimize generic protocols

### DIFF
--- a/src/obspec/_list.py
+++ b/src/obspec/_list.py
@@ -73,7 +73,7 @@ class ListStream(Protocol[ListChunkType_co]):
         ...
 
 
-class List(Protocol[ListChunkType_co]):
+class List(Protocol):
     @overload
     def list(
         self,
@@ -192,7 +192,7 @@ class List(Protocol[ListChunkType_co]):
         ...
 
 
-class ListWithDelimiter(Protocol[ListChunkType_co]):
+class ListWithDelimiter(Protocol):
     @overload
     def list_with_delimiter(
         self,
@@ -245,7 +245,7 @@ class ListWithDelimiter(Protocol[ListChunkType_co]):
         ...
 
 
-class ListWithDelimiterAsync(Protocol[ListChunkType_co]):
+class ListWithDelimiterAsync(Protocol):
     @overload
     async def list_with_delimiter_async(
         self,


### PR DESCRIPTION
The `List`, `ListWithDelimiter`, and `ListWithDelimiterAsync` protocols don't themselves need to be generic; only the `ListResult` and `ListStream`