### PR TITLE
Split sync and async return iterators for `Get` and `List`

### DIFF
--- a/docs/api/get.md
+++ b/docs/api/get.md
@@ -8,6 +8,8 @@
 ::: obspec.GetRangesAsync
 ::: obspec.GetOptions
 ::: obspec.GetResult
+::: obspec.GetResultAsync
+::: obspec.BufferIterator
 ::: obspec.BufferStream
 ::: obspec.OffsetRange
 ::: obspec.SuffixRange

--- a/docs/api/list.md
+++ b/docs/api/list.md
@@ -1,8 +1,10 @@
 # List
 
 ::: obspec.List
+::: obspec.ListAsync
 ::: obspec.ListWithDelimiter
 ::: obspec.ListWithDelimiterAsync
 ::: obspec.ListResult
+::: obspec.ListIterator
 ::: obspec.ListStream
 ::: obspec.ListChunkType_co

--- a/src/obspec/__init__.py
+++ b/src/obspec/__init__.py
@@ -3,6 +3,7 @@ from ._attributes import Attribute, Attributes
 from ._copy import Copy, CopyAsync
 from ._delete import Delete, DeleteAsync
 from ._get import (
+    BufferIterator,
     BufferStream,
     Get,
     GetAsync,
@@ -12,13 +13,16 @@ from ._get import (
     GetRanges,
     GetRangesAsync,
     GetResult,
+    GetResultAsync,
     OffsetRange,
     SuffixRange,
 )
 from ._head import Head, HeadAsync
 from ._list import (
     List,
+    ListAsync,
     ListChunkType_co,
+    ListIterator,
     ListResult,
     ListStream,
     ListWithDelimiter,
@@ -32,6 +36,7 @@ from ._version import __version__
 __all__ = [
     "Attribute",
     "Attributes",
+    "BufferIterator",
     "BufferStream",
     "Copy",
     "CopyAsync",
@@ -45,10 +50,13 @@ __all__ = [
     "GetRanges",
     "GetRangesAsync",
     "GetResult",
+    "GetResultAsync",
     "Head",
     "HeadAsync",
     "List",
+    "ListAsync",
     "ListChunkType_co",
+    "ListIterator",
     "ListResult",
     "ListStream",
     "ListWithDelimiter",

--- a/src/obspec/_list.py
+++ b/src/obspec/_list.py
@@ -21,7 +21,7 @@ Then an Arrow `RecordBatch` will be returned instead.
 
 
 class ListResult(TypedDict, Generic[ListChunkType_co]):
-    """Result of a list call.
+    """Result of a `list_with_delimiter` call.
 
     Includes objects, prefixes (directories) and a token for the next set of results.
     Individual result sets may be limited to 1,000 objects based on the underlying
@@ -36,9 +36,7 @@ class ListResult(TypedDict, Generic[ListChunkType_co]):
 
 
 class ListIterator(Protocol[ListChunkType_co]):
-    """A stream of [ObjectMeta][obspec.ObjectMeta] that can be polled in a sync or
-    async fashion.
-    """  # noqa: D205
+    """A stream of [ObjectMeta][obspec.ObjectMeta] that can be polled synchronously."""
 
     def __iter__(self) -> Self:
         """Return `Self` as an async iterator."""
@@ -58,9 +56,7 @@ class ListIterator(Protocol[ListChunkType_co]):
 
 
 class ListStream(Protocol[ListChunkType_co]):
-    """A stream of [ObjectMeta][obspec.ObjectMeta] that can be polled in a sync or
-    async fashion.
-    """  # noqa: D205
+    """A stream of [ObjectMeta][obspec.ObjectMeta] that can be polled asynchronously."""
 
     def __aiter__(self) -> Self:
         """Return `Self` as an async iterator."""


### PR DESCRIPTION
In obstore it's very convenient to have a single method that returns both an async and a sync iterator. You can call `list()` and iterate over either with `for` or `async for`. 

But I imagine that some obspec implementations will be either only sync or only async. In this case, we don't want to require that the returned value can always be iterated over in both manners.

So it's probably good to have some separation in the protocol. Here, this PR suggests a separation between `Get` and `GetAsync` where `Get` returns a synchronous iterator and `GetAsync` returns an async iterator. I think this should be compatible with obstore because obstore's iterators are a superset.

It would be nice to have a single `list` named method still, but it doesn't look like Python can intersect the return objects. So you can't have a `List` and `ListAsync` protocol that each define `def list()`, even if you could imagine having an intersection of their return iterators.

In practice, this means that obstore would need to get an essentially duplicative `list_async` method. Even though that function would return the same thing as `obstore.list`

Closes #10 

cc @sharkinsspatial @maxrjones @TomNicholas