### PR TITLE
Edit docstring for `Copy`

### DIFF
--- a/src/obspec/_copy.py
+++ b/src/obspec/_copy.py
@@ -7,20 +7,27 @@ class Copy(Protocol):
     def copy(self, from_: str, to: str, *, overwrite: bool = True) -> None:
         """Copy an object from one path to another in the same object store.
 
+        All paths should be a fragment relative to the bucket root or any prefix already
+        assigned on the store. I.e. `path/to/file.txt`, not
+        `s3://bucket/path/to/file.txt`.
+
         Args:
-            from_: Source path
+            from_: Source path.
             to: Destination path
 
         Keyword Args:
-            overwrite: If `True`, if there exists an object at the destination, it will
+            overwrite: whether to overwrite the destination object if one already
+                exists.
+
+                - If `True`, if there exists an object at the destination, it will
                     be overwritten.
 
-                If `False`: will copy only if destination is empty. Performs an atomic
+                - If `False`: will copy only if destination is empty. Performs an atomic
                 operation if the underlying object storage supports it. If atomic
-                operations are not supported by the underlying object storage (like S3)
-                it will return an error.
+                operations are not supported by the underlying object storage it will
+                return an error.
 
-                Will return an error if the destination already has an object.
+                    Will return an error if the destination already has an object.
 
         """
 


### PR DESCRIPTION
- We probably want some generic documentation that covers how the API is semantically intended to be used, aside from just the type hints themselves