### PR TITLE
feat: Use Sequence instead of list in type hints

### DIFF
--- a/src/obspec/_get.py
+++ b/src/obspec/_get.py
@@ -83,7 +83,7 @@ class GetOptions(TypedDict, total=False):
     <https://datatracker.ietf.org/doc/html/rfc9110#section-13.1.4>
     """
 
-    range: tuple[int, int] | list[int] | OffsetRange | SuffixRange
+    range: tuple[int, int] | Sequence[int] | OffsetRange | SuffixRange
     """
     Request transfer of only the specified range of bytes.
 
@@ -371,7 +371,7 @@ class GetRanges(Protocol):
         starts: Sequence[int],
         ends: Sequence[int] | None = None,
         lengths: Sequence[int] | None = None,
-    ) -> list[Buffer]:
+    ) -> Sequence[Buffer]:
         """Return the bytes stored at the specified location in the given byte ranges.
 
         To improve performance this will:
@@ -407,7 +407,7 @@ class GetRangesAsync(Protocol):
         starts: Sequence[int],
         ends: Sequence[int] | None = None,
         lengths: Sequence[int] | None = None,
-    ) -> list[Buffer]:
+    ) -> Sequence[Buffer]:
         """Call `get_ranges` asynchronously.
 
         Refer to the documentation for [GetRanges][obspec.GetRanges].

--- a/src/obspec/_list.py
+++ b/src/obspec/_list.py
@@ -1,13 +1,22 @@
 from __future__ import annotations
 
-from typing import Generic, Literal, Protocol, Self, TypedDict, TypeVar, overload
+from collections.abc import Sequence
+from typing import (
+    Generic,
+    Literal,
+    Protocol,
+    Self,
+    TypedDict,
+    TypeVar,
+    overload,
+)
 
 from ._meta import ObjectMeta
 from .arrow import ArrowArrayExportable, ArrowStreamExportable
 
 ListChunkType_co = TypeVar(
     "ListChunkType_co",
-    list[ObjectMeta],
+    Sequence[ObjectMeta],
     ArrowArrayExportable,
     ArrowStreamExportable,
     covariant=True,
@@ -28,7 +37,7 @@ class ListResult(TypedDict, Generic[ListChunkType_co]):
     object storage's limitations.
     """
 
-    common_prefixes: list[str]
+    common_prefixes: Sequence[str]
     """Prefixes that are common (like directories)"""
 
     objects: ListChunkType_co
@@ -93,7 +102,7 @@ class List(Protocol):
         offset: str | None = None,
         chunk_size: int = 50,
         return_arrow: Literal[False] = False,
-    ) -> ListIterator[list[ObjectMeta]]: ...
+    ) -> ListIterator[Sequence[ObjectMeta]]: ...
     def list(
         self,
         prefix: str | None = None,
@@ -101,7 +110,7 @@ class List(Protocol):
         offset: str | None = None,
         chunk_size: int = 50,
         return_arrow: bool = False,
-    ) -> ListIterator[ArrowArrayExportable] | ListIterator[list[ObjectMeta]]:
+    ) -> ListIterator[ArrowArrayExportable] | ListIterator[Sequence[ObjectMeta]]:
         """List all the objects with the given prefix.
 
         Prefixes are evaluated on a path segment basis, i.e. `foo/bar/` is a prefix of
@@ -192,7 +201,7 @@ class ListAsync(Protocol):
         offset: str | None = None,
         chunk_size: int = 50,
         return_arrow: Literal[False] = False,
-    ) -> ListStream[list[ObjectMeta]]: ...
+    ) -> ListStream[Sequence[ObjectMeta]]: ...
     def list_async(
         self,
         prefix: str | None = None,
@@ -200,7 +209,7 @@ class ListAsync(Protocol):
         offset: str | None = None,
         chunk_size: int = 50,
         return_arrow: bool = False,
-    ) -> ListStream[ArrowArrayExportable] | ListStream[list[ObjectMeta]]:
+    ) -> ListStream[ArrowArrayExportable] | ListStream[Sequence[ObjectMeta]]:
         """List all the objects with the given prefix.
 
         Note that this method itself is **not async**. It's a synchronous method but
@@ -260,13 +269,13 @@ class ListWithDelimiter(Protocol):
         prefix: str | None = None,
         *,
         return_arrow: Literal[False] = False,
-    ) -> ListResult[list[ObjectMeta]]: ...
+    ) -> ListResult[Sequence[ObjectMeta]]: ...
     def list_with_delimiter(
         self,
         prefix: str | None = None,
         *,
         return_arrow: bool = False,
-    ) -> ListResult[ArrowStreamExportable] | ListResult[list[ObjectMeta]]:
+    ) -> ListResult[ArrowStreamExportable] | ListResult[Sequence[ObjectMeta]]:
         """List objects with the given prefix and an implementation specific
         delimiter.
 
@@ -313,13 +322,13 @@ class ListWithDelimiterAsync(Protocol):
         prefix: str | None = None,
         *,
         return_arrow: Literal[False] = False,
-    ) -> ListResult[list[ObjectMeta]]: ...
+    ) -> ListResult[Sequence[ObjectMeta]]: ...
     async def list_with_delimiter_async(
         self,
         prefix: str | None = None,
         *,
         return_arrow: bool = False,
-    ) -> ListResult[ArrowStreamExportable] | ListResult[list[ObjectMeta]]:
+    ) -> ListResult[ArrowStreamExportable] | ListResult[Sequence[ObjectMeta]]:
         """Call `list_with_delimiter` asynchronously.
 
         Refer to the documentation for


### PR DESCRIPTION
[This](https://hackmd.io/@vickyliin/Syz0Zc_iC) is a good quick note on variance in Python and [this](https://hackmd.io/@vickyliin/ry66U__s0) is a good resource on variance of `list` vs `Sequence`:

### Key Terms

1. **Covariant**: If A is a subtype of B, then Container[A] is a subtype of Container[B].
2. **Contravariant**: If A is a subtype of B, then Container[B] is a subtype of Container[A].
3. **Invariant**: Neither covariant nor contravariant. Container[A] and Container[B] are not related, even if A and B are.

`list` is invariant while `Sequence` is covariant.

We want our type hints to be covariant so that users can return a subtype of `ObjectMeta`.