### PR TITLE
feat: Remove `chunk_size` parameter on list calls

### DIFF
--- a/src/obspec/_get.py
+++ b/src/obspec/_get.py
@@ -171,7 +171,7 @@ class GetResult(Protocol):
         """
         ...
 
-    def __iter__(self) -> BufferStream:
+    def __iter__(self) -> BufferIterator:
         """Return a chunked stream over the result's bytes."""
         ...
 

--- a/src/obspec/_get.py
+++ b/src/obspec/_get.py
@@ -92,7 +92,7 @@ class GetOptions(TypedDict, total=False):
     """
     Request transfer of only the specified range of bytes.
 
-    The semantics of this tuple are:
+    The semantics of this attribute are:
 
     - `(int, int)`: Request a specific range of bytes `(start, end)`.
 
@@ -130,18 +130,18 @@ class GetOptions(TypedDict, total=False):
 class GetResult(Protocol):
     """Result for a get request.
 
-    You can materialize the entire buffer by using `bytes`, or you can stream the result
-    using `stream`. `__iter__` is implemented as an alias to `stream`, so you can
-    alternatively call `iter()` on `GetResult` to start an iterator.
+    You can materialize the entire buffer by calling the `bytes` method or you can
+    stream the result by iterating over it .
 
     **Example:**
 
     ```py
-    resp = obs.get(store, path)
-    # 20MB chunk size in stream
-    stream = resp.stream(min_chunk_size=20 * 1024 * 1024)
-    for buf in stream:
-        print(len(buf))
+    from obspec import Get
+
+    def streaming_download(client: Get, path: str):
+        resp = client.get(path)
+        for buffer in resp:
+            print(len(buffer))
     ```
     """
 
@@ -171,43 +171,26 @@ class GetResult(Protocol):
         """
         ...
 
-    def stream(self, min_chunk_size: int = 10 * 1024 * 1024) -> BufferIterator:
-        r"""Return a chunked stream over the result's bytes.
-
-        Args:
-            min_chunk_size: The minimum size in bytes for each chunk in the returned
-                `BufferStream`. All chunks except for the last chunk will be at least
-                this size. Defaults to 10\*1024\*1024 (10MB).
-
-        Returns:
-            A chunked stream
-
-        """
-        ...
-
     def __iter__(self) -> BufferStream:
-        """Return a chunked stream over the result's bytes.
-
-        Uses the default (10MB) chunk size.
-        """
+        """Return a chunked stream over the result's bytes."""
         ...
 
 
 class GetResultAsync(Protocol):
     """Result for an async get request.
 
-    You can materialize the entire buffer by using `bytes_async`, or you can stream the
-    result using `stream`. `__aiter__` is implemented as an alias to `stream`, so you
-    can alternatively call `aiter()` on `GetResult` to start an iterator.
+    You can materialize the entire buffer by calling the `bytes_async` method or you can
+    stream the result by asynchronously iterating over it.
 
     **Example:**
 
     ```py
-    resp = await obs.get_async(store, path)
-    # 5MB chunk size in stream
-    stream = resp.stream(min_chunk_size=5 * 1024 * 1024)
-    async for buf in stream:
-        print(len(buf))
+    from obspec import GetAsync
+
+    async def streaming_download(obs: GetAsync, path: str):
+        resp = await client.get_async(path)
+        async for buffer in resp:
+            print(len(buffer))
     ```
     """
 
@@ -234,20 +217,6 @@ class GetResultAsync(Protocol):
         """The range of bytes returned by this request.
 
         Note that this is `(start, stop)` **not** `(start, length)`.
-
-        """
-        ...
-
-    def stream(self, min_chunk_size: int = 10 * 1024 * 1024) -> BufferStream:
-        r"""Return a chunked stream over the result's bytes.
-
-        Args:
-            min_chunk_size: The minimum size in bytes for each chunk in the returned
-                `BufferStream`. All chunks except for the last chunk will be at least
-                this size. Defaults to 10\*1024\*1024 (10MB).
-
-        Returns:
-            A chunked stream
 
         """
         ...
@@ -294,7 +263,7 @@ class Get(Protocol):
         """Return the bytes that are stored at the specified location.
 
         Args:
-            path: The path within ObjectStore to retrieve.
+            path: The path within the store to retrieve.
             options: options for accessing the file. Defaults to None.
 
         Returns:
@@ -335,7 +304,7 @@ class GetRange(Protocol):
         exact requested range will be returned.
 
         Args:
-            path: The path within ObjectStore to retrieve.
+            path: The path within the store to retrieve.
 
         Keyword Args:
             start: The start of the byte range.
@@ -345,8 +314,7 @@ class GetRange(Protocol):
                 be non-None.
 
         Returns:
-            A `Buffer` object implementing the Python buffer protocol, allowing
-                zero-copy access to the underlying memory provided by Rust.
+            A `Buffer` object implementing the Python buffer protocol.
 
         """
         ...
@@ -379,14 +347,11 @@ class GetRanges(Protocol):
     ) -> Sequence[Buffer]:
         """Return the bytes stored at the specified location in the given byte ranges.
 
-        To improve performance this will:
-
-        - Transparently combine ranges less than 1MB apart into a single underlying
-          request
-        - Make multiple `fetch` requests in parallel (up to maximum of 10)
+        The choice of how to implement multiple range requests is implementation
+        specific.
 
         Args:
-            path: The path within ObjectStore to retrieve.
+            path: The path within the store to retrieve.
 
         Other Args:
             starts: A sequence of `int` where each offset starts.
@@ -396,9 +361,8 @@ class GetRanges(Protocol):
                 Either `ends` or `lengths` must be non-None.
 
         Returns:
-            A sequence of `Buffer`, one for each range. This `Buffer` object implements
-            the Python buffer protocol, allowing zero-copy access to the underlying
-            memory provided by Rust.
+            A sequence of `Buffer`, one for each range, each implementing the Python
+            buffer protocol.
 
         """
         ...

--- a/src/obspec/_head.py
+++ b/src/obspec/_head.py
@@ -11,7 +11,7 @@ class Head(Protocol):
         """Return the metadata for the specified location.
 
         Args:
-            path: The path within ObjectStore to retrieve.
+            path: The path within the store to retrieve.
 
         Returns:
             ObjectMeta

--- a/src/obspec/_list.py
+++ b/src/obspec/_list.py
@@ -72,7 +72,6 @@ class List(Protocol):
         prefix: str | None = None,
         *,
         offset: str | None = None,
-        chunk_size: int = 50,
     ) -> ListIterator[Sequence[ObjectMeta]]:
         """List all the objects with the given prefix.
 
@@ -92,7 +91,7 @@ class List(Protocol):
                 client.put(f"file{i}.txt", b"foo")
 
         def list_files(client: obspec.List):
-            stream = client.list(chunk_size=10)
+            stream = client.list()
             for list_result in stream:
                 print(list_result[0])
                 # {'path': 'file0.txt', 'last_modified': datetime.datetime(2024, 10, 23, 19, 19, 28, 781723, tzinfo=datetime.timezone.utc), 'size': 3, 'e_tag': '0', 'version': None}
@@ -104,17 +103,14 @@ class List(Protocol):
             guaranteed
 
         Args:
-            prefix: The prefix within ObjectStore to use for listing. Defaults to None.
+            prefix: The prefix within the store to use for listing. Defaults to None.
 
         Keyword Args:
             offset: If provided, list all the objects with the given prefix and a
                 location greater than `offset`. Defaults to `None`.
-            chunk_size: The number of items to collect per chunk in the returned
-                (async) iterator. All chunks except for the last one will have this many
-                items.
 
         Returns:
-            A ListStream, which you can iterate through to access list results.
+            A ListIterator, which you can iterate through to access list results.
 
         """  # noqa: E501
         ...
@@ -126,7 +122,6 @@ class ListAsync(Protocol):
         prefix: str | None = None,
         *,
         offset: str | None = None,
-        chunk_size: int = 50,
     ) -> ListStream[Sequence[ObjectMeta]]:
         """List all the objects with the given prefix.
 
@@ -140,7 +135,7 @@ class ListAsync(Protocol):
         Asynchronously iterate through list results. Just change `for` to `async for`:
 
         ```py
-        stream = obs.list_async(store, chunk_size=10)
+        stream = obs.list_async(store)
         async for list_result in stream:
             print(list_result[2])
             # {'path': 'file10.txt', 'last_modified': datetime.datetime(2024, 10, 23, 19, 21, 46, 224725, tzinfo=datetime.timezone.utc), 'size': 3, 'e_tag': '10', 'version': None}
@@ -152,14 +147,11 @@ class ListAsync(Protocol):
             guaranteed
 
         Args:
-            prefix: The prefix within ObjectStore to use for listing. Defaults to None.
+            prefix: The prefix within the store to use for listing. Defaults to None.
 
         Keyword Args:
             offset: If provided, list all the objects with the given prefix and a
                 location greater than `offset`. Defaults to `None`.
-            chunk_size: The number of items to collect per chunk in the returned
-                (async) iterator. All chunks except for the last one will have this many
-                items.
 
         Returns:
             A ListStream, which you can iterate through to access list results.
@@ -189,7 +181,7 @@ class ListWithDelimiter(Protocol):
             the paths in the result.
 
         Args:
-            prefix: The prefix within ObjectStore to use for listing. Defaults to None.
+            prefix: The prefix within the store to use for listing. Defaults to None.
 
         Returns:
             ListResult

--- a/src/obspec/_list.py
+++ b/src/obspec/_list.py
@@ -43,14 +43,14 @@ class ListResult(TypedDict, Generic[ListChunkType_co]):
 
 
 class ListIterator(Protocol[ListChunkType_co]):
-    """A stream of [ObjectMeta][obspec.ObjectMeta] that can be polled synchronously."""
+    """An iterator of [ObjectMeta][obspec.ObjectMeta] that can be polled synchronously."""  # noqa: E501
 
     def __iter__(self) -> Self:
-        """Return `Self` as an async iterator."""
+        """Return `Self` as an iterator."""
         ...
 
     def __next__(self) -> ListChunkType_co:
-        """Return the next chunk of ObjectMeta in the stream."""
+        """Return the next chunk of ObjectMeta in the iterator."""
         ...
 
 

--- a/tests/test-get.yml
+++ b/tests/test-get.yml
@@ -16,6 +16,5 @@
     def accepts_get(client: Get) -> None:
         resp = client.get("path/to/file")
         assert_type(resp.range, tuple[int, int])
-        buffer_iterator = resp.stream()
-        for chunk in buffer_iterator:
+        for chunk in resp:
             assert_type(chunk, Buffer)


### PR DESCRIPTION
### Change list

- Remove `stream` method on `GetResult` and `GetResultAsync`
- Remove `chunk_size` parameter in list calls
- Fix GetResult to return BufferIterator
- Remove more references to obstore
- Update docstrings
- Fix examples

Closes #33 