### PR TITLE
chore: Simplify iterator types by using stdlib types

### DIFF
--- a/docs/api/get.md
+++ b/docs/api/get.md
@@ -9,7 +9,5 @@
 ::: obspec.GetOptions
 ::: obspec.GetResult
 ::: obspec.GetResultAsync
-::: obspec.BufferIterator
-::: obspec.BufferStream
 ::: obspec.OffsetRange
 ::: obspec.SuffixRange

--- a/docs/api/list.md
+++ b/docs/api/list.md
@@ -5,6 +5,4 @@
 ::: obspec.ListWithDelimiter
 ::: obspec.ListWithDelimiterAsync
 ::: obspec.ListResult
-::: obspec.ListIterator
-::: obspec.ListStream
 ::: obspec.ListChunkType_co

--- a/src/obspec/__init__.py
+++ b/src/obspec/__init__.py
@@ -3,8 +3,6 @@ from ._attributes import Attribute, Attributes
 from ._copy import Copy, CopyAsync
 from ._delete import Delete, DeleteAsync
 from ._get import (
-    BufferIterator,
-    BufferStream,
     Get,
     GetAsync,
     GetOptions,
@@ -22,9 +20,7 @@ from ._list import (
     List,
     ListAsync,
     ListChunkType_co,
-    ListIterator,
     ListResult,
-    ListStream,
     ListWithDelimiter,
     ListWithDelimiterAsync,
 )
@@ -36,8 +32,6 @@ from ._version import __version__
 __all__ = [
     "Attribute",
     "Attributes",
-    "BufferIterator",
-    "BufferStream",
     "Copy",
     "CopyAsync",
     "Delete",
@@ -56,9 +50,7 @@ __all__ = [
     "List",
     "ListAsync",
     "ListChunkType_co",
-    "ListIterator",
     "ListResult",
-    "ListStream",
     "ListWithDelimiter",
     "ListWithDelimiterAsync",
     "ObjectMeta",

--- a/src/obspec/_get.py
+++ b/src/obspec/_get.py
@@ -1,24 +1,20 @@
 from __future__ import annotations
 
+import sys
+from collections.abc import AsyncIterable, Iterable
 from typing import TYPE_CHECKING, Protocol, TypedDict
 
+if sys.version_info >= (3, 12):
+    from collections.abc import Buffer
+else:
+    from typing_extensions import Buffer
+
 if TYPE_CHECKING:
-    import sys
     from collections.abc import Sequence
     from datetime import datetime
 
     from ._attributes import Attributes
     from ._meta import ObjectMeta
-
-    if sys.version_info >= (3, 11):
-        from typing import Self
-    else:
-        from typing_extensions import Self
-
-    if sys.version_info >= (3, 12):
-        from collections.abc import Buffer
-    else:
-        from typing_extensions import Buffer
 
 
 class OffsetRange(TypedDict):
@@ -127,7 +123,7 @@ class GetOptions(TypedDict, total=False):
     """
 
 
-class GetResult(Protocol):
+class GetResult(Iterable[Buffer], Protocol):
     """Result for a get request.
 
     You can materialize the entire buffer by calling the `bytes` method or you can
@@ -171,12 +167,8 @@ class GetResult(Protocol):
         """
         ...
 
-    def __iter__(self) -> BufferIterator:
-        """Return a chunked stream over the result's bytes."""
-        ...
 
-
-class GetResultAsync(Protocol):
+class GetResultAsync(AsyncIterable[Buffer], Protocol):
     """Result for an async get request.
 
     You can materialize the entire buffer by calling the `bytes_async` method or you can
@@ -219,37 +211,6 @@ class GetResultAsync(Protocol):
         Note that this is `(start, stop)` **not** `(start, length)`.
 
         """
-        ...
-
-    def __aiter__(self) -> BufferStream:
-        """Return a chunked stream over the result's bytes.
-
-        Uses the default (10MB) chunk size.
-        """
-        ...
-
-
-class BufferIterator(Protocol):
-    """A synchronous iterator of bytes."""
-
-    def __iter__(self) -> Self:
-        """Return `Self` as an async iterator."""
-        ...
-
-    def __next__(self) -> Buffer:
-        """Return the next Buffer chunk in the stream."""
-        ...
-
-
-class BufferStream(Protocol):
-    """An asynchronous iterator of bytes."""
-
-    def __aiter__(self) -> Self:
-        """Return `Self` as an async iterator."""
-        ...
-
-    async def __anext__(self) -> Buffer:
-        """Return the next Buffer chunk in the stream."""
         ...
 
 

--- a/src/obspec/_list.py
+++ b/src/obspec/_list.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import sys
-from collections.abc import Sequence
 from typing import TYPE_CHECKING, Generic, Protocol, TypeVar
 
 # Note: we need to use the typing-extensions typed dict because we also parametrize over
@@ -13,14 +12,9 @@ else:
     from typing_extensions import TypedDict
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import AsyncIterator, Iterator, Sequence
 
     from ._meta import ObjectMeta
-
-    if sys.version_info >= (3, 11):
-        from typing import Self
-    else:
-        from typing_extensions import Self
 
 
 ListChunkType_co = TypeVar("ListChunkType_co", covariant=True)
@@ -42,37 +36,13 @@ class ListResult(TypedDict, Generic[ListChunkType_co]):
     """Object metadata for the listing"""
 
 
-class ListIterator(Protocol[ListChunkType_co]):
-    """An iterator of [ObjectMeta][obspec.ObjectMeta] that can be polled synchronously."""  # noqa: E501
-
-    def __iter__(self) -> Self:
-        """Return `Self` as an iterator."""
-        ...
-
-    def __next__(self) -> ListChunkType_co:
-        """Return the next chunk of ObjectMeta in the iterator."""
-        ...
-
-
-class ListStream(Protocol[ListChunkType_co]):
-    """A stream of [ObjectMeta][obspec.ObjectMeta] that can be polled asynchronously."""
-
-    def __aiter__(self) -> Self:
-        """Return `Self` as an async iterator."""
-        ...
-
-    async def __anext__(self) -> ListChunkType_co:
-        """Return the next chunk of ObjectMeta in the stream."""
-        ...
-
-
 class List(Protocol):
     def list(
         self,
         prefix: str | None = None,
         *,
         offset: str | None = None,
-    ) -> ListIterator[Sequence[ObjectMeta]]:
+    ) -> Iterator[Sequence[ObjectMeta]]:
         """List all the objects with the given prefix.
 
         Prefixes are evaluated on a path segment basis, i.e. `foo/bar/` is a prefix of
@@ -122,7 +92,7 @@ class ListAsync(Protocol):
         prefix: str | None = None,
         *,
         offset: str | None = None,
-    ) -> ListStream[Sequence[ObjectMeta]]:
+    ) -> AsyncIterator[Sequence[ObjectMeta]]:
         """List all the objects with the given prefix.
 
         Note that this method itself is **not async**. It's a synchronous method but


### PR DESCRIPTION
### Change list

- Remove `BufferIterator` in favor of `Iterator[Buffer]`
- Remove `BufferStream` in favor of `AsyncIterator[Buffer]`
- Remove `ListIterator` in favor of `Iterator[ObjectMeta]`
- Remove `ListStream` in favor of `AsyncIterator[ObjectMeta]`