### PR TITLE
blog: fix `[obspec.Get]` link

### DIFF
--- a/docs/blog/posts/introducing-obspec.md
+++ b/docs/blog/posts/introducing-obspec.md
@@ -81,7 +81,7 @@ def iterate_over_file_object(fs: AbstractFileSystem, path: str):
 
 ### Obspec: Streaming download
 
-By mapping more closely to the underlying HTTP requests, obspec makes it clearer what HTTP requests are happening under the hood. [obspec.Get] allows for streaming a file download via a Python iterator:
+By mapping more closely to the underlying HTTP requests, obspec makes it clearer what HTTP requests are happening under the hood. [obspec.Get][obspec.Get] allows for streaming a file download via a Python iterator:
 
 ```py
 from obspec import Get


### PR DESCRIPTION
For some reason, [`[obspec.Get]`](https://github.com/developmentseed/obspec/blob/6c74dc0e10bff82c08c530af37dca96cf25c39fe/docs/blog/posts/introducing-obspec.md#L84) is not rendering as a link:

<img width="713" alt="image" src="https://github.com/user-attachments/assets/e6be22d2-45e7-4505-91d0-1410a7afeefa" />

but [``[`get`][obspec.Get]``](https://github.com/developmentseed/obspec/blob/6c74dc0e10bff82c08c530af37dca96cf25c39fe/docs/blog/posts/introducing-obspec.md#L120) is, later in the doc:

<img width="641" alt="image" src="https://github.com/user-attachments/assets/9c671de4-6564-4a94-9081-dd16bcb2d771" />

I poked around [mkdocs](https://www.mkdocs.org/) / [pymdownx](https://facelessuser.github.io/pymdown-extensions/) docs/configs, but didn't see a way to make sure they're detecting links of the form `[X]` (which should be treated like `[X][X]`, where in this case should expand to [the relevant docs](https://developmentseed.org/obspec/latest/api/get/#obspec.Get)), so I just manually expanded it here.

From local `mkdocs serve`:

<img width="704" alt="image" src="https://github.com/user-attachments/assets/06a0dff4-9fba-44d3-8c56-79a6c9004038" />
