### PR TITLE
docs: Use newer python version to publish docs

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -32,8 +32,8 @@ jobs:
           enable-cache: true
           version: "0.5.x"
 
-      - name: Set up Python 3.11
-        run: uv python install 3.11
+      - name: Set up Python 3.13
+        run: uv python install 3.13
 
       - name: Install dependencies
         run: uv sync


### PR DESCRIPTION
Was just thinking maybe this would fix the un-linked `Buffer`:
<img width="730" height="148" alt="image" src="https://github.com/user-attachments/assets/0b77bf8b-f892-46df-810c-bf3d2f0c0cb6" />
